### PR TITLE
Test whole emacs module

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Ran 1 tests, 1 results as expected (2018-06-21 16:48:28-0400, 0.000766 sec)
 - modules directory of Emacs repository
 - [Go + Emacs Modules](https://mrosset.github.io/emacs-module/)
 - [GPL Compatible Licenses](https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses)
+- [Emacs Modules Documentation](http://phst.github.io/emacs-modules.html)
 
 
 [diobla]: http://diobla.info/blog-archive/modules-tut.html

--- a/emacs_module.nim
+++ b/emacs_module.nim
@@ -171,6 +171,7 @@ type
                     vec: emacs_value; i: ptrdiff_t; val: emacs_value) {.cdecl.}
     vec_size*: proc (env: ptr emacs_env; vec: emacs_value): ptrdiff_t {.cdecl.}
 
-proc emacs_module_init*(ert: ptr emacs_runtime): cint
-    {.importc: "emacs_module_init", header: "<emacs-module.h>".} ## \
-      ## Every module should define a function as follows.
+# TODO: Below seems to be unused
+# proc emacs_module_init*(ert: ptr emacs_runtime): cint
+#     {.importc: "emacs_module_init", header: "<emacs-module.h>".} ## \
+#       ## Every module should define a function as follows.

--- a/emacs_module/helpers.nim
+++ b/emacs_module/helpers.nim
@@ -83,17 +83,18 @@ emacs_module_init (struct emacs_runtime *ert)
 """, self.functions, self.libName)
 
 
-template provide*(self: typed): typed {.dirty.} =
+template provide*(self: Emacs) {.dirty.} =
   static:
     const temp = self.provideString()
   {.emit: temp.}
 
 
-template init*(sym: untyped): untyped {.dirty.} =
+template init*(sym: untyped) {.dirty.} =
   from os import splitFile
 
   static:
-    var sym = Emacs()
+    var `sym` = Emacs()
     let info = instantiationInfo()
     sym.functions = ""
+    # If the file name is foo.nim, let the libary name to foo.
     sym.libName = splitFile(info.filename).name

--- a/emacs_module/helpers.nim
+++ b/emacs_module/helpers.nim
@@ -8,8 +8,8 @@ type Emacs* = object
 
 
 proc pushFunction*(self: var Emacs, fn: string, max_args: int) =
-  ## Push function name `fn` to `functions` object.
-  ## This variable is used later by `provide` proc.
+  ## Push function name ``fn`` to ``functions`` object.
+  ## This variable is used later by ``provide`` proc.
   let
     emacs_func = replace(self.libName & "-" & fn, "_", "-")
     nim_func = "nimEmacs_" & self.libName & "_" & fn
@@ -20,7 +20,7 @@ proc pushFunction*(self: var Emacs, fn: string, max_args: int) =
   )
 
 
-template defun*(self, fsym, max_args, body: untyped) {.dirty.} = ## \
+template defun*(self: Emacs; fsym: untyped; max_args: int; body: untyped) {.dirty.} = ## \
   ## emacs_func(env: ptr emacs_env, nargs: ptrdiff_t,
   ## args: ptr array[0..max_args, emacs_value], data: pointer):
   ## emacs_value {.exportc.}
@@ -37,7 +37,7 @@ template defun*(self, fsym, max_args, body: untyped) {.dirty.} = ## \
     body
 
 
-proc provideString* (self: var Emacs): string =
+proc provideString* (self: Emacs): string =
   format("""
 /* Lisp utilities for easier readability (simple wrappers).  */
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,10 +1,11 @@
 # !! Set EMACS_MODULE_DIR to the directory containing the emacs-module.h !!
-EMACS_MODULE_DIR ?= $(shell dirname `which emacs`)
+# EMACS_MODULE_DIR ?= $(shell dirname `which emacs`)
+EMACS_MODULE_DIR ?= ../include/emacs27/
 EMACS ?= emacs
 
 NIM_CFLAGS = --passC:-I$(EMACS_MODULE_DIR) --passC:-std=gnu99
 
-.PHONY: return42 test_return42 sample test_sample clean test all
+.PHONY: return42 test_return42 sample test_sample modtest test_modtest clean test all
 
 
 ## return42
@@ -27,9 +28,19 @@ test_sample:
 	$(EMACS) --batch -L . $(LOADPATH) -l test-sample.el -f ert-run-tests-batch-and-exit
 
 
+## modtest
+modtest: clean modtest.so test_modtest
+
+modtest.so: modtest.nim
+	nim c --out:modtest.so --app:lib $(NIM_CFLAGS) $<
+
+test_modtest:
+	$(EMACS) --batch -L . $(LOADPATH) -l test-modtest.el -f ert-run-tests-batch-and-exit
+
+
 clean:
 	rm -fr nimcache *.so
 
-test: test_return42 test_sample
+test: test_return42 test_sample test_modtest
 
-all: return42 sample
+all: return42 sample modtest

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,5 @@
 # !! Set EMACS_MODULE_DIR to the directory containing the emacs-module.h !!
-# EMACS_MODULE_DIR ?= $(shell dirname `which emacs`)
-EMACS_MODULE_DIR ?= ../include/emacs27/
+EMACS_MODULE_DIR ?= $(shell dirname `which emacs`)
 EMACS ?= emacs
 
 NIM_CFLAGS = --passC:-I$(EMACS_MODULE_DIR) --passC:-std=gnu99

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -215,6 +215,7 @@ emacs.defun(return_t, 1):
 
 emacs.defun(get_type, 1):
   ## Returns the Emacs-Lisp symbol of the argument type.
+  ## See http://git.savannah.gnu.org/cgit/emacs.git/tree/src/data.c?id=5583e6460c38c5d613e732934b066421349a5259#n204.
   env.type_of(env, args[0])
 
 emacs.defun(is_true, 1):

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -129,6 +129,12 @@ emacs.defun(throw, 0):
     EMACS_ATTRIBUTE_NONNULL(1, 2);
 ]#
 
+emacs.defun(make_string, 2):
+  ## Returns string created by Emacs-Lisp ``make-string``.
+  let
+    fSymbol = env.intern(env, "make-string") # Get 'make-string
+  return env.funcall(env, fSymbol, nargs, addr args[0]) # Return the (funcall make-string ..) returned elisp string
+
 emacs.defun(return_t, 1):
   env.intern(env, "t".cstring)
 
@@ -232,11 +238,11 @@ emacs.defun(lazy, 0):
 emacs.defun(hello, 1):
   ## Returns "Hello " prefixed to the passed string argument.
   var l: ptrdiff_t
-  if (env.copy_string_contents(env, args[0], nil, addr l)):
-    var name = newString(l-1)
-    if (env.copy_string_contents(env, args[0], addr name[0], addr l)):
-      var res = "Hello " & name
-      result = env.make_string(env, addr res[0], res.len)
+  if (env.copy_string_contents(env, args[0], nil, addr l)): # Get the length of the elisp string args[0] (it's num chars + 1).
+    var name = newString(l-1) # So the actual string length is l-1. Allocate that much space for the name string in Nim.
+    if (env.copy_string_contents(env, args[0], addr name[0], addr l)): # *Now* copy the elisp string args[0] to Nim string name.
+      var res = "Hello " & name # Create a new Nim string res using the name string.
+      return env.make_string(env, addr res[0], res.len) # Convert the Nim string res to elisp string before returning.
 
 from osproc import execCmdEx
 from strutils import strip

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -53,6 +53,19 @@ struct emacs_env_26
 #[
   /* Non-local exit handling.  */
 
+  #[
+      Exit status enum:
+
+      /* Function has returned normally.  */
+      emacs_funcall_exit_return = 0,
+
+      /* Function has signaled an error using `signal'.  */
+      emacs_funcall_exit_signal = 1,
+
+      /* Function has exit using `throw'.  */
+      emacs_funcall_exit_throw = 2,
+  ]#
+
   enum emacs_funcall_exit (*non_local_exit_check) (emacs_env *env)
     EMACS_ATTRIBUTE_NONNULL(1);
 

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -145,14 +145,24 @@ emacs.defun(return_t, 1):
     EMACS_ATTRIBUTE_NONNULL(1);
 ]#
 
+emacs.defun(get_type, 1):
+  ## Returns the Emacs-Lisp symbol of the argument type.
+  env.type_of(env, args[0])
+
+emacs.defun(is_true, 1):
+  ## Returns ``t`` if argument is non-nil, else returns ``nil``.
+  if env.is_not_nil(env, args[0]):
+    env.intern(env, "t")
+  else:
+    env.intern(env, "nil")
+
 emacs.defun(sum, 2):
+  ## Returns the sum of two integers.
   assert(nargs == 2)
   let
     a = env.extract_integer(env, args[0])
     b = env.extract_integer(env, args[1])
-    s = a + b
-
-  env.make_integer(env, s)
+  env.make_integer(env, a + b)
 
 #[
   /* Create a Lisp string from a utf8 encoded string.  */

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -289,7 +289,7 @@ emacs.defun(uname, 1):
     EMACS_ATTRIBUTE_NONNULL(1);
 ]#
 
-# vec_get
+# vec_size, vec_get
 emacs.defun(vector_eq, 2):
   var
     vec = args[0]
@@ -300,7 +300,7 @@ emacs.defun(vector_eq, 2):
       result = env.intern(env, "nil")
   result = env.intern(env, "t")
 
-# vec_size
+# vec_size, vec_set
 emacs.defun(vector_fill, 2):
   var
     vec = args[0]

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -169,6 +169,14 @@ emacs.defun(is_true, 1):
   else:
     env.intern(env, "nil")
 
+emacs.defun(eq, 2):
+  ## Returns ``t`` if both arguments are the same Lisp object, else returns ``nil``.
+  ## Note that this returns the value of Emacs-Lisp ``eq``, not ``equal``.
+  if env.eq(env, args[0], args[1]):
+    env.intern(env, "t")
+  else:
+    env.intern(env, "nil")
+
 emacs.defun(sum, 2):
   ## Returns the sum of two integers.
   assert(nargs == 2)

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -55,7 +55,7 @@ struct emacs_env_26
 
 emacs.defun(globref_make, 0):
   ## Make a big string and make it global.
-  var str: string
+  var str: string = ""
   for i in 0 ..< (26 * 100):
     str.add(char('a'.ord + (i mod 26)))
   let lispStr = env.make_string(env, addr str[0], str.len)

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -53,21 +53,13 @@ struct emacs_env_26
     EMACS_ATTRIBUTE_NONNULL(1);
 ]#
 
-# /* Return a global reference.  */
-# static emacs_value
-# Fmod_test_globref_make (emacs_env *env, ptrdiff_t nargs, emacs_value args[],
-# 			void *data)
-# {
-#   /* Make a big string and make it global.  */
-#   char str[26 * 100];
-#   for (int i = 0; i < sizeof str; i++)
-#     str[i] = 'a' + (i % 26);
-
-#   /* We don't need to null-terminate str.  */
-#   emacs_value lisp_str = env->make_string (env, str, sizeof str);
-#   return env->make_global_ref (env, lisp_str);
-# }
-
+emacs.defun(globref_make, 0):
+  ## Make a big string and make it global.
+  var str: string
+  for i in 0 ..< (26 * 100):
+    str.add(char('a'.ord + (i mod 26)))
+  let lispStr = env.make_string(env, addr str[0], str.len)
+  return env.make_global_ref(env, lispStr)
 
 #[
   /* Non-local exit handling.  */

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -179,11 +179,21 @@ emacs.defun(eq, 2):
 
 emacs.defun(sum, 2):
   ## Returns the sum of two integers.
-  assert(nargs == 2)
+  # assert(nargs == 2)
+  # The above assert statement is never reached! Emacs throws the
+  # "wrong-number-of-arguments" error signal before the execution
+  # reaches this assert statement.
   let
     a = env.extract_integer(env, args[0])
     b = env.extract_integer(env, args[1])
   env.make_integer(env, a + b)
+
+emacs.defun(sum_float, 2):
+  ## Returns the sum of two floats.
+  let
+    a = env.extract_float(env, args[0])
+    b = env.extract_float(env, args[1])
+  env.make_float(env, a + b)
 
 #[
   /* Create a Lisp string from a utf8 encoded string.  */

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -184,6 +184,7 @@ emacs.defun(make_string, 2):
   return env.funcall(env, fSymbol, nargs, addr args[0]) # Return the (funcall make-string ..) returned elisp string
 
 emacs.defun(return_t, 1):
+  ## Returns ``t``, always.
   env.intern(env, "t")
 
 #[

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -136,7 +136,7 @@ emacs.defun(make_string, 2):
   return env.funcall(env, fSymbol, nargs, addr args[0]) # Return the (funcall make-string ..) returned elisp string
 
 emacs.defun(return_t, 1):
-  env.intern(env, "t".cstring)
+  env.intern(env, "t")
 
 #[
   /* Type conversion.  */

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -1,0 +1,275 @@
+#[
+
+License:
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+]#
+
+# `plugin_is_GPL_compatible` indicates that its code is
+# released under the GPL or compatible license; Emacs will refuse to
+# load modules that don't export such a symbol.
+{.emit:"int plugin_is_GPL_compatible;".}
+
+import emacs_module             # primitive wrapper for emacs_module.h
+import emacs_module/helpers     # helper library
+
+init(emacs)
+
+#[
+struct emacs_env_26
+{
+
+  /* Structure size (for version checking).  */
+  ptrdiff_t size;
+
+  /* Private data; users should not touch this.  */
+  struct emacs_env_private *private_members;
+]#
+
+#[
+  /* Memory management.  */
+
+  emacs_value (*make_global_ref) (emacs_env *env,
+				  emacs_value any_reference)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  void (*free_global_ref) (emacs_env *env,
+			   emacs_value global_reference)
+    EMACS_ATTRIBUTE_NONNULL(1);
+]#
+
+#[
+  /* Non-local exit handling.  */
+
+  enum emacs_funcall_exit (*non_local_exit_check) (emacs_env *env)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  void (*non_local_exit_clear) (emacs_env *env)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  enum emacs_funcall_exit (*non_local_exit_get)
+    (emacs_env *env,
+     emacs_value *non_local_exit_symbol_out,
+     emacs_value *non_local_exit_data_out)
+    EMACS_ATTRIBUTE_NONNULL(1, 2, 3);
+
+  void (*non_local_exit_signal) (emacs_env *env,
+				 emacs_value non_local_exit_symbol,
+				 emacs_value non_local_exit_data)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  void (*non_local_exit_throw) (emacs_env *env,
+				emacs_value tag,
+				emacs_value value)
+    EMACS_ATTRIBUTE_NONNULL(1);
+]#
+
+# non_local_exit_check, non_local_exit_signal
+emacs.defun(signal, 0):
+  assert(env.non_local_exit_check(env) == emacs_funcall_exit_return)
+  env.non_local_exit_signal(env, env.intern(env, "error"),
+                            env.make_integer(env, 100))
+
+# non_local_exit_check, non_local_exit_throw
+emacs.defun(throw, 0):
+  assert(env.non_local_exit_check(env) == emacs_funcall_exit_return)
+  env.non_local_exit_throw(env, env.intern(env, "tag"),
+                           env.make_integer(env, 42))
+  result = env.intern(env, "nil")
+
+#[
+  /* Function registration.  */
+
+  emacs_value (*make_function) (emacs_env *env,
+				ptrdiff_t min_arity,
+				ptrdiff_t max_arity,
+				emacs_value (*function) (emacs_env *env,
+							 ptrdiff_t nargs,
+							 emacs_value args[],
+							 void *)
+				  EMACS_NOEXCEPT
+                                  EMACS_ATTRIBUTE_NONNULL(1),
+				const char *documentation,
+				void *data)
+    EMACS_ATTRIBUTE_NONNULL(1, 4);
+
+  emacs_value (*funcall) (emacs_env *env,
+                          emacs_value function,
+                          ptrdiff_t nargs,
+                          emacs_value args[])
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  emacs_value (*intern) (emacs_env *env,
+                         const char *symbol_name)
+    EMACS_ATTRIBUTE_NONNULL(1, 2);
+]#
+
+emacs.defun(return_t, 1):
+  env.intern(env, "t".cstring)
+
+#[
+  /* Type conversion.  */
+
+  emacs_value (*type_of) (emacs_env *env,
+			  emacs_value value)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  bool (*is_not_nil) (emacs_env *env, emacs_value value)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  bool (*eq) (emacs_env *env, emacs_value a, emacs_value b)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  intmax_t (*extract_integer) (emacs_env *env, emacs_value value)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  emacs_value (*make_integer) (emacs_env *env, intmax_t value)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  double (*extract_float) (emacs_env *env, emacs_value value)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  emacs_value (*make_float) (emacs_env *env, double value)
+    EMACS_ATTRIBUTE_NONNULL(1);
+]#
+
+emacs.defun(sum, 2):
+  assert(nargs == 2)
+  let
+    a = env.extract_integer(env, args[0])
+    b = env.extract_integer(env, args[1])
+    s = a + b
+
+  env.make_integer(env, s)
+
+#[
+  /* Create a Lisp string from a utf8 encoded string.  */
+  emacs_value (*make_string) (emacs_env *env,
+			      const char *contents, ptrdiff_t length)
+    EMACS_ATTRIBUTE_NONNULL(1, 2);
+]#
+
+# make_string
+emacs.defun(lazy, 0):
+  ## Returns a string constant.
+  var str = "The quick brown fox jumped over the lazy dog."
+  return env.make_string(env, addr str[0], str.len)
+
+#[
+  /* Copy the content of the Lisp string VALUE to BUFFER as an utf8
+     null-terminated string.
+
+     SIZE must point to the total size of the buffer.  If BUFFER is
+     NULL or if SIZE is not big enough, write the required buffer size
+     to SIZE and return true.
+
+     Note that SIZE must include the last null byte (e.g. "abc" needs
+     a buffer of size 4).
+
+     Return true if the string was successfully copied.  */
+
+  bool (*copy_string_contents) (emacs_env *env,
+                                emacs_value value,
+                                char *buffer,
+                                ptrdiff_t *size_inout)
+    EMACS_ATTRIBUTE_NONNULL(1, 4);
+]#
+
+# copy_string_contents, make_string
+emacs.defun(hello, 1):
+  ## Returns "Hello " prefixed to the passed string argument.
+  var l: ptrdiff_t
+  if (env.copy_string_contents(env, args[0], nil, addr l)):
+    var name = newString(l-1)
+    if (env.copy_string_contents(env, args[0], addr name[0], addr l)):
+      var res = "Hello " & name
+      result = env.make_string(env, addr res[0], res.len)
+
+from osproc import execCmdEx
+from strutils import strip
+emacs.defun(uname, 1):
+  ## Returns the output of the ``uname`` command run the passed string argument.
+  var l: ptrdiff_t
+  if (env.copy_string_contents(env, args[0], nil, addr l)):
+    var unameArg = newString(l-1)
+    if (env.copy_string_contents(env, args[0], addr unameArg[0], addr l)):
+      var (res, _) = execCmdEx("uname " & unameArg)
+      res = res.strip()
+      result = env.make_string(env, addr res[0], res.len)
+
+#[
+  /* Embedded pointer type.  */
+  emacs_value (*make_user_ptr) (emacs_env *env,
+				void (*fin) (void *) EMACS_NOEXCEPT,
+				void *ptr)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  void *(*get_user_ptr) (emacs_env *env, emacs_value uptr)
+    EMACS_ATTRIBUTE_NONNULL(1);
+  void (*set_user_ptr) (emacs_env *env, emacs_value uptr, void *ptr)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  void (*(*get_user_finalizer) (emacs_env *env, emacs_value uptr))
+    (void *) EMACS_NOEXCEPT EMACS_ATTRIBUTE_NONNULL(1);
+  void (*set_user_finalizer) (emacs_env *env,
+			      emacs_value uptr,
+			      void (*fin) (void *) EMACS_NOEXCEPT)
+    EMACS_ATTRIBUTE_NONNULL(1);
+]#
+
+#[
+  /* Vector functions.  */
+  emacs_value (*vec_get) (emacs_env *env, emacs_value vec, ptrdiff_t i)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  void (*vec_set) (emacs_env *env, emacs_value vec, ptrdiff_t i,
+		   emacs_value val)
+    EMACS_ATTRIBUTE_NONNULL(1);
+
+  ptrdiff_t (*vec_size) (emacs_env *env, emacs_value vec)
+    EMACS_ATTRIBUTE_NONNULL(1);
+]#
+
+# vec_get
+emacs.defun(vector_eq, 2):
+  var
+    vec = args[0]
+    val = args[1]
+    size = env.vec_size(env, vec)
+  for i in 0 ..< size:
+    if not env.eq(env, env.vec_get(env, vec, i), val):
+      result = env.intern(env, "nil")
+  result = env.intern(env, "t")
+
+# vec_size
+emacs.defun(vector_fill, 2):
+  var
+    vec = args[0]
+    val = args[1]
+    size = env.vec_size(env, vec)
+
+  for i in 0 ..< size:
+    env.vec_set(env, vec, i, val)
+  result = env.intern(env, "t")
+
+#[
+  /* Returns whether a quit is pending.  */
+  bool (*should_quit) (emacs_env *env)
+    EMACS_ATTRIBUTE_NONNULL(1);
+};
+]#
+
+
+emacs.provide()                 # (provide 'modtest)

--- a/test/modtest.nim
+++ b/test/modtest.nim
@@ -133,22 +133,20 @@ emacs.defun(non_local_exit_funcall, 1):
     env.non_local_exit_clear(env)
     let
       Flist = env.intern(env, "list")
+    var
       listArgs: array[3, emacs_value] = [env.intern(env, "signal"),
                                          non_local_exit_symbol,
                                          non_local_exit_data]
-    # TODO: Need to understand why unsafeAddr needs to be used below
-    # instead of addr. Using addr gives this error: expression has no
-    # address; maybe use 'unsafeAddr'. Though.. with unsafeAddr, this
-    # function seems to work fine.
-    return env.funcall(env, Flist, 3, unsafeAddr listArgs[0])
+    return env.funcall(env, Flist, 3, addr listArgs[0])
   of emacs_funcall_exit_throw:
     env.non_local_exit_clear(env)
     let
       Flist = env.intern(env, "list")
+    var
       listArgs: array[3, emacs_value] = [env.intern(env, "throw"),
                                          non_local_exit_symbol,
                                          non_local_exit_data]
-    return env.funcall(env, Flist, 3, unsafeAddr listArgs[0])
+    return env.funcall(env, Flist, 3, addr listArgs[0])
 
 #[
   /* Function registration.  */

--- a/test/test-modtest.el
+++ b/test/test-modtest.el
@@ -60,6 +60,7 @@
 (ert-deftest modtest-get-type ()
   (should (eq 'string (modtest-get-type "abc")))
   (should (eq 'integer (modtest-get-type 42)))
+  (should (eq 'integer (modtest-get-type (point))))
   (should (eq 'float (modtest-get-type 42.0)))
   (should (eq 'symbol (modtest-get-type nil)))
   (should (eq 'symbol (modtest-get-type t)))
@@ -67,7 +68,10 @@
   (should (eq 'cons (modtest-get-type (cons 1 2))))
   (should (eq 'cons (modtest-get-type '(1 . 2))))
   (should (eq 'cons (modtest-get-type '(1 2 3)))) ;Interestingly, this is a "cons" too.
-  (should (eq 'cons (modtest-get-type (list 1 2 3))))) ;.. and this too!
+  (should (eq 'cons (modtest-get-type (list 1 2 3)))) ;.. and this too!
+  (should (eq 'window-configuration (modtest-get-type (current-window-configuration))))
+  (should (eq 'marker (modtest-get-type (point-marker))))
+  (should (eq 'buffer (modtest-get-type (current-buffer)))))
 
 (ert-deftest modtest-is-true ()
   (should (eq nil (modtest-is-true nil)))

--- a/test/test-modtest.el
+++ b/test/test-modtest.el
@@ -27,6 +27,14 @@
 (require 'modtest)
 
 
+;; TODO: It's not clear how to test if `modtest-globref-make' is doing
+;; the right thing.
+(ert-deftest modtest-globref-make ()
+  (let ((refstr ""))
+    (dotimes (i 100)
+      (setq refstr (concat refstr "abcdefghijklmnopqrstuvwxyz")))
+    (should (string= refstr (modtest-globref-make)))))
+
 (ert-deftest modtest-non-local-exit-signal-test ()
   (should-error (modtest-signal)))
 

--- a/test/test-modtest.el
+++ b/test/test-modtest.el
@@ -1,0 +1,73 @@
+;;; test-modtest.el --- test modtest.nim -*- lexical-binding: t; -*-
+
+;; Author: Kaushal Modi <kaushal.modi@gmail.com>
+
+;;; License:
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;;; Commentary:
+
+;;; Code:
+
+(require 'ert)
+
+(add-to-list 'load-path
+             (file-name-directory (or #$ (expand-file-name (buffer-file-name)))))
+
+(require 'modtest)
+
+
+(ert-deftest modtest-non-local-exit-signal-test ()
+  (should-error (modtest-signal)))
+
+(ert-deftest modtest-non-local-exit-throw-test ()
+  (should (equal
+           (catch 'tag
+             (modtest-throw)
+             (ert-fail "expected throw"))
+           42)))
+
+(ert-deftest modtest-return-t ()
+  (should (eq t (modtest-return-t 0)))
+  (should (eq t (modtest-return-t "abc")))
+  (should (eq t (modtest-return-t t)))
+  (should (eq t (modtest-return-t nil)))
+  (should (eq t (modtest-return-t ?a))))
+
+(ert-deftest modtest-sum ()
+  (should (eq 10 (modtest-sum 3 7)))
+  (should-error (modtest-sum "1" 2) :type 'wrong-type-argument)
+  (should-error (modtest-sum 2 "1") :type 'wrong-type-argument))
+
+(ert-deftest modtest-string ()
+  (should (string= "The quick brown fox jumped over the lazy dog." (modtest-lazy)))
+  (should (string= "Hello World" (modtest-hello "World"))))
+
+(ert-deftest modtest-uname ()
+  (let ((ref-uname-a-output (progn
+                              (require 'subr-x)
+                              (string-trim (shell-command-to-string "uname -a")))))
+    (should (string= ref-uname-a-output (modtest-uname "-a")))))
+
+(ert-deftest modtest-vector-test ()
+  (dolist (s '(2 10 100 1000))
+    (dolist (e '(42 foo "foo" 3.14))
+      (let* ((v-ref (make-vector 2 e))
+             (eq-ref (eq (aref v-ref 0) (aref v-ref 1)))
+             (v-test (make-vector s nil)))
+
+        (should (eq (modtest-vector-fill v-test e) t))
+        (should (eq (modtest-vector-eq v-test e) eq-ref))))))
+
+
+;;; test-modtest.el ends here

--- a/test/test-modtest.el
+++ b/test/test-modtest.el
@@ -45,6 +45,21 @@
              (ert-fail "expected throw"))
            42)))
 
+(ert-deftest modtest-non-local-exit-funcall ()
+  ;; emacs_funcall_exit_return
+  (should (equal t (modtest-non-local-exit-funcall (lambda () t))))
+  (should (equal 123 (modtest-non-local-exit-funcall (lambda () 123))))
+  ;; emacs_funcall_exit_signal
+  (should (equal '(signal user-error ("oh noes!"))
+                 (modtest-non-local-exit-funcall
+                  (lambda ()
+                    (user-error "oh noes!")))))
+  ;; emacs_funcall_exit_throw
+  (should (equal '(throw foo 123)
+                 (modtest-non-local-exit-funcall
+                  (lambda ()
+                    (throw 'foo 123))))))
+
 (ert-deftest modtest-make-string ()
   (should (string= "--" (modtest-make-string 2 ?-)))
   (should (string= "aaaaa" (modtest-make-string 5 ?a)))

--- a/test/test-modtest.el
+++ b/test/test-modtest.el
@@ -37,6 +37,11 @@
              (ert-fail "expected throw"))
            42)))
 
+(ert-deftest modtest-make-string ()
+  (should (string= "--" (modtest-make-string 2 ?-)))
+  (should (string= "aaaaa" (modtest-make-string 5 ?a)))
+  (should (string= "" (modtest-make-string 0 ?a))))
+
 (ert-deftest modtest-return-t ()
   (should (eq t (modtest-return-t 0)))
   (should (eq t (modtest-return-t "abc")))

--- a/test/test-modtest.el
+++ b/test/test-modtest.el
@@ -84,9 +84,18 @@
   (should (eq nil (modtest-eq (cons 1 2) (cons 1 2))))) ;These are *not* the same Lisp objects!
 
 (ert-deftest modtest-sum ()
-  (should (eq 10 (modtest-sum 3 7)))
+  (should (equal 10 (modtest-sum 3 7)))
+  (should-error (modtest-sum 3) :type 'wrong-number-of-arguments)
   (should-error (modtest-sum "1" 2) :type 'wrong-type-argument)
-  (should-error (modtest-sum 2 "1") :type 'wrong-type-argument))
+  (should-error (modtest-sum 2 "1") :type 'wrong-type-argument)
+  (should-error (modtest-sum 2.0 1.0) :type 'wrong-type-argument))
+
+(ert-deftest modtest-sum-float ()
+  (should (equal 10.0 (modtest-sum-float 3.3 6.7)))
+  (should-error (modtest-sum-float 3.0) :type 'wrong-number-of-arguments)
+  (should-error (modtest-sum-float "1" 2) :type 'wrong-type-argument)
+  (should-error (modtest-sum-float 2 "1") :type 'wrong-type-argument)
+  (should-error (modtest-sum-float 2 1) :type 'wrong-type-argument))
 
 (ert-deftest modtest-string ()
   (should (string= "The quick brown fox jumped over the lazy dog." (modtest-lazy)))

--- a/test/test-modtest.el
+++ b/test/test-modtest.el
@@ -27,6 +27,23 @@
 (require 'modtest)
 
 
+(ert-deftest modtest-non-local-exit-signal-test ()
+  (should-error (modtest-signal)))
+
+(ert-deftest modtest-non-local-exit-throw-test ()
+  (should (equal
+           (catch 'tag
+             (modtest-throw)
+             (ert-fail "expected throw"))
+           42)))
+
+(ert-deftest modtest-return-t ()
+  (should (eq t (modtest-return-t 0)))
+  (should (eq t (modtest-return-t "abc")))
+  (should (eq t (modtest-return-t t)))
+  (should (eq t (modtest-return-t nil)))
+  (should (eq t (modtest-return-t ?a))))
+
 (ert-deftest modtest-get-type ()
   (should (eq 'string (modtest-get-type "abc")))
   (should (eq 'integer (modtest-get-type 42)))
@@ -54,22 +71,17 @@
   (should (eq t (modtest-is-true '(1 2 3))))
   (should (eq t (modtest-is-true (list 1 2 3)))))
 
-(ert-deftest modtest-non-local-exit-signal-test ()
-  (should-error (modtest-signal)))
-
-(ert-deftest modtest-non-local-exit-throw-test ()
-  (should (equal
-           (catch 'tag
-             (modtest-throw)
-             (ert-fail "expected throw"))
-           42)))
-
-(ert-deftest modtest-return-t ()
-  (should (eq t (modtest-return-t 0)))
-  (should (eq t (modtest-return-t "abc")))
-  (should (eq t (modtest-return-t t)))
-  (should (eq t (modtest-return-t nil)))
-  (should (eq t (modtest-return-t ?a))))
+(ert-deftest modtest-eq ()
+  (should (eq t (modtest-eq nil nil)))
+  (should (eq t (modtest-eq t t)))
+  (should (eq nil (modtest-eq nil t)))
+  (should (eq nil (modtest-eq "abc" "abc"))) ;These are *not* the same Lisp objects!
+  (should (eq nil (modtest-eq "" nil)))
+  (should (eq t (modtest-eq 42 42)))
+  (should (eq t (modtest-eq ?a ?a)))
+  (should (eq nil (modtest-eq 42 43)))
+  (should (eq nil (modtest-eq 42.0 42.0))) ;These are *not* the same Lisp objects!
+  (should (eq nil (modtest-eq (cons 1 2) (cons 1 2))))) ;These are *not* the same Lisp objects!
 
 (ert-deftest modtest-sum ()
   (should (eq 10 (modtest-sum 3 7)))

--- a/test/test-modtest.el
+++ b/test/test-modtest.el
@@ -27,6 +27,33 @@
 (require 'modtest)
 
 
+(ert-deftest modtest-get-type ()
+  (should (eq 'string (modtest-get-type "abc")))
+  (should (eq 'integer (modtest-get-type 42)))
+  (should (eq 'float (modtest-get-type 42.0)))
+  (should (eq 'symbol (modtest-get-type nil)))
+  (should (eq 'symbol (modtest-get-type t)))
+  (should (eq 'symbol (modtest-get-type '())))
+  (should (eq 'cons (modtest-get-type (cons 1 2))))
+  (should (eq 'cons (modtest-get-type '(1 . 2))))
+  (should (eq 'cons (modtest-get-type '(1 2 3)))) ;Interestingly, this is a "cons" too.
+  (should (eq 'cons (modtest-get-type (list 1 2 3))))) ;.. and this too!
+
+(ert-deftest modtest-is-true ()
+  (should (eq nil (modtest-is-true nil)))
+  (should (eq nil (modtest-is-true '())))
+  (should (eq nil (modtest-is-true ())))
+  (should (eq nil (modtest-is-true (not t))))
+  (should (eq t (modtest-is-true "abc")))
+  (should (eq t (modtest-is-true "")))
+  (should (eq t (modtest-is-true 42)))
+  (should (eq t (modtest-is-true 42.0)))
+  (should (eq t (modtest-is-true t)))
+  (should (eq t (modtest-is-true (cons 1 2))))
+  (should (eq t (modtest-is-true '(1 . 2))))
+  (should (eq t (modtest-is-true '(1 2 3))))
+  (should (eq t (modtest-is-true (list 1 2 3)))))
+
 (ert-deftest modtest-non-local-exit-signal-test ()
   (should-error (modtest-signal)))
 


### PR DESCRIPTION
This PR adds modtest.nim that attempts to test all the emacs-module.h API.

I will need help from you and @Lompik to make the coverage full.

There are also small edits in helpers.nim related to specifying the exact types, etc.