### PR TITLE
Fix the compilation failure on devel

### DIFF
--- a/emacs_module/helpers.nim
+++ b/emacs_module/helpers.nim
@@ -82,18 +82,18 @@ emacs_module_init (struct emacs_runtime *ert)
 """, self.functions, self.libName)
 
 
-template provide*(self: Emacs) {.dirty.} =
-  static:
-    const temp = self.provideString()
+template provide*(self: Emacs): typed {.dirty.} =
+  const temp = `self`.provideString()
   {.emit: temp.}
 
 
 template init*(sym: untyped) {.dirty.} =
   from os import splitFile
 
+  var `sym` {.compileTime.} = Emacs()
+
   static:
-    var `sym` = Emacs()
     let info = instantiationInfo()
-    sym.functions = ""
-    # If the file name is foo.nim, let the libary name to foo.
-    sym.libName = splitFile(info.filename).name
+    `sym`.functions = ""
+    # If the file name is foo.nim, set the libary name to foo.
+    `sym`.libName = splitFile(info.filename).name


### PR DESCRIPTION
https://github.com/nim-lang/Nim/commit/95436893061176d51b1c11fdf5418b3ed17a8455
on Nim devel now makes the static blocks work like other blocks
i.e. vars declared inside those scopes do not leak outside.

This commit fixes helpers.nim for that static block behavior change.

Fixes https://github.com/yuutayamada/nim-emacs-module/issues/15.

I have tested this PR on Nim 0.18.0 too.. `make sample` works.